### PR TITLE
Docker cargo caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,10 @@ bin/*
 # Rust ignores
 app/target
 app/Cargo.lock
+
+# MacOS garbage:
 *.DS_Store
+
+# Cargo build caching, so changes in Docker build do not require re-indexing crates
+.cargo_build_cache/*
+!.cargo_build_cache/.keep

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,5 +5,6 @@ services:
       context: ./docker/builder
       dockerfile: Dockerfile
     volumes:
-      - ./app:/app
-      - ./bin:/build/bin
+      - ./app:/app # source code input
+      - ./bin:/build/bin # compiled result output
+      - ./.cargo_build_cache:/root/.cargo/registry # Cache Rust dependencies

--- a/docker/builder/build_watch.sh
+++ b/docker/builder/build_watch.sh
@@ -17,7 +17,7 @@ build () {
 echo -e "\e[1;34m Starting initial build... \e[0m"
 build
 echo -e "\e[1;34m Watch started. \e[0m"
-inotifywait -mq -r -e create -e modify -e delete -e move ./src |
+inotifywait -mq -r -e create -e modify -e delete -e move ./src ./data ./Cargo.toml ./build.rs ./wrapper.h ./powerpc-unknown-eabi.json |
     while read dir action file; do
         echo -e "\e[1;34m The file '$file' appeared in directory '$dir' via '$action', rebuilding... \e[0m"
         build


### PR DESCRIPTION
A small PR with two nice little improvements to the build process:
- Cache the crate registry between Docker builds. This means that even when the Dockerfile changes, Rust crates do not need to be re-downloaded. (They will be re-compiled for good measure though). This is especially nice/important when working on a not-so-good internet connection. (Trains, jam venues).
- Improve the `inotifywatch` command so rebuilds are also triggered when `Cargo.toml`, files inside `app/data` and other humanly-modified files in the `./app` directory change.