### PR TITLE
Make the docker image that is being built smaller.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
     volumes:
       - ./app:/app # source code input
       - ./bin:/build/bin # compiled result output
-      - ./.cargo_build_cache:/root/.cargo/registry # Cache Rust dependencies
+      - ./.cargo_build_cache:/usr/local/cargo/registry # Cache Rust dependencies

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,12 +1,14 @@
-FROM ubuntu:22.04
+FROM ghcr.io/rust-lang/rust:nightly-slim
 
 # Install Wii Dev environment
 WORKDIR /
-RUN apt-get update
-RUN apt-get install -y sudo wget inotify-tools unzip build-essential clang libclang-dev dosfstools
 COPY install-devkitpro-pacman.sh /install-devkitpro-pacman.sh
 RUN chmod +x ./install-devkitpro-pacman.sh
-RUN sudo ./install-devkitpro-pacman.sh
+RUN apt-get update && \
+  apt-get install -y sudo wget inotify-tools unzip build-essential clang libclang-dev dosfstools && \
+  sudo ./install-devkitpro-pacman.sh && \
+  apt-get purge -y && \
+  rm -rf /var/lib/apt/lists/*
 RUN if [ ! -f /etc/mtab ]; then sudo ln -s /proc/self/mounts /etc/mtab; fi;
 RUN sudo dkp-pacman --noconfirm -S wii-dev
 
@@ -16,8 +18,7 @@ ENV DEVKITPPC="${DEVKITPRO}/devkitPPC"
 ENV PATH="${PATH}:${DEVKITPPC}/bin/"
 
 # Install Wii 3D Dev lib: GRRLIB
-RUN curl -L https://github.com/GRRLIB/GRRLIB/archive/master.zip > GRRLIB.zip
-RUN unzip GRRLIB.zip && rm GRRLIB.zip
+RUN curl -L https://github.com/GRRLIB/GRRLIB/archive/master.zip > GRRLIB.zip && unzip GRRLIB.zip && rm GRRLIB.zip
 WORKDIR /GRRLIB-master/GRRLIB/
 RUN sudo dkp-pacman --sync --needed --noconfirm libfat-ogc ppc-libpng ppc-freetype ppc-libjpeg-turbo
 RUN make clean all install

--- a/docker/builder/build_watch.sh
+++ b/docker/builder/build_watch.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Load rust config vars
-source "$HOME/.cargo/env"
-
 # Set the CWD to the app folder
 cd /app
 

--- a/docker/builder/install_rust.sh
+++ b/docker/builder/install_rust.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source "$HOME/.cargo/env"
-rustup default nightly
+# #!/usr/bin/env bash
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# source "$HOME/.cargo/env"
+# rustup default nightly
 rustup component add rust-src --toolchain nightly


### PR DESCRIPTION
This is a WIP; I still want to improve the readability of the resulting dockerfile somewhat.

Techniques used:
- Use debian-slim nightly rust docker image as base.
  - Custom `rustup` commands no longer necessary.
- Combine all `apt-get` commands and purge after installation.

So far this results in a docker image that is just 2.6GB rather than the 4.5GB that it was before.