### PR TITLE
Removes unused has-elf-tls field from target json file that produced warnings

### DIFF
--- a/app/powerpc-unknown-eabi.json
+++ b/app/powerpc-unknown-eabi.json
@@ -6,7 +6,6 @@
     "env": "newlib",
     "exe-suffix": ".elf",
     "executables": true,
-    "has-elf-tls": false,
     "has-rpath": true,
     "llvm-target": "powerpc-unknown-eabi",
     "linker": "powerpc-eabi-gcc",


### PR DESCRIPTION

The warning:
```
 warning: target json file contains unused fields: has-elf-tls
```

would come up for each crate that is compiled. This PR fixes this issue.

Please double-check whether the code still builds correctly on your machine to be sure!