### PR TITLE
Add 'clippy' and 'rustfmt' to the build process.

### DIFF
--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::all)]
+#![allow(clippy::all)]
 include!("renderer/grrlib.rs");
 
 mod inline;

--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -1,22 +1,24 @@
-#![allow(clippy::all)]
+// Skip Clippy warnings for this module and nested modules:
+#[allow(clippy:all)]
+
 include!("renderer/grrlib.rs");
 
 mod inline;
 pub use inline::*;
 
 mod model_factory;
-pub use model_factory::ModelFactory;
+pub use model_factory::{ModelFactory};
 
-use crate::{Position, Velocity};
 use hecs::*;
 use ogc_rs::print;
 use wavefront::Obj;
+use crate::{Position, Velocity};
 
 /**
  * Data structure for the renderer.
  */
 pub struct Renderer {
-    model_factory: ModelFactory<'static>,
+    model_factory : ModelFactory<'static>
 }
 
 /**
@@ -28,14 +30,14 @@ impl Renderer {
      */
     pub fn new() -> Renderer {
         Renderer {
-            model_factory: ModelFactory::new(),
+            model_factory: ModelFactory::new()
         }
     }
 
     /**
      * Allows for rendering the given object.
      */
-    fn render_mesh(object: &Obj) {
+    fn render_mesh(object : & Obj) {
         let col: [u32; 3] = [0xFFFFFFFF, 0xAAAAAAFF, 0x666666FF];
         unsafe {
             let vertex_count = (object.triangles().count() * 3) as u16;
@@ -58,59 +60,59 @@ impl Renderer {
         let col: [u32; 3] = [0xFFFFFFFF, 0xAAAAAAFF, 0x666666FF];
         unsafe {
             GX_Begin(GX_QUADS as u8, GX_VTXFMT0 as u8, 24u16);
-            GX_Position3f32(-1.0, 1.0, -1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(-1.0, -1.0, -1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(1.0, -1.0, -1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(1.0, 1.0, -1.0);
-            GX_Color1u32(col[0]);
+                GX_Position3f32(-1.0, 1.0, -1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(-1.0,-1.0,-1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(1.0,-1.0,-1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(1.0,1.0,-1.0);
+                GX_Color1u32(col[0]);
 
-            GX_Position3f32(-1.0, 1.0, 1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(-1.0, -1.0, 1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(1.0, -1.0, 1.0);
-            GX_Color1u32(col[0]);
-            GX_Position3f32(1.0, 1.0, 1.0);
-            GX_Color1u32(col[0]);
+                GX_Position3f32(-1.0,1.0,1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(-1.0,-1.0,1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(1.0,-1.0,1.0);
+                GX_Color1u32(col[0]);
+                GX_Position3f32(1.0,1.0,1.0);
+                GX_Color1u32(col[0]);
 
-            GX_Position3f32(-1.0, 1.0, 1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(1.0, 1.0, 1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(1.0, 1.0, -1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(-1.0, 1.0, -1.0);
-            GX_Color1u32(col[1]);
+                GX_Position3f32(-1.0,1.0,1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(1.0,1.0,1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(1.0,1.0,-1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(-1.0,1.0,-1.0);
+                GX_Color1u32(col[1]);
 
-            GX_Position3f32(-1.0, -1.0, 1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(1.0, -1.0, 1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(1.0, -1.0, -1.0);
-            GX_Color1u32(col[1]);
-            GX_Position3f32(-1.0, -1.0, -1.0);
-            GX_Color1u32(col[1]);
+                GX_Position3f32(-1.0,-1.0,1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(1.0,-1.0,1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(1.0,-1.0,-1.0);
+                GX_Color1u32(col[1]);
+                GX_Position3f32(-1.0,-1.0,-1.0);
+                GX_Color1u32(col[1]);
 
-            GX_Position3f32(-1.0, 1.0, 1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(-1.0, 1.0, -1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(-1.0, -1.0, -1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(-1.0, -1.0, 1.0);
-            GX_Color1u32(col[2]);
+                GX_Position3f32(-1.0,1.0,1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(-1.0,1.0,-1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(-1.0,-1.0,-1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(-1.0,-1.0,1.0);
+                GX_Color1u32(col[2]);
 
-            GX_Position3f32(1.0, 1.0, 1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(1.0, 1.0, -1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(1.0, -1.0, -1.0);
-            GX_Color1u32(col[2]);
-            GX_Position3f32(1.0, -1.0, 1.0);
-            GX_Color1u32(col[2]);
+                GX_Position3f32(1.0,1.0,1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(1.0,1.0,-1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(1.0,-1.0,-1.0);
+                GX_Color1u32(col[2]);
+                GX_Position3f32(1.0,-1.0,1.0);
+                GX_Color1u32(col[2]);
             GX_End();
         }
     }
@@ -124,7 +126,11 @@ impl Renderer {
             GRRLIB_Settings.antialias = true;
 
             GRRLIB_SetBackgroundColour(0x00, 0x00, 0x00, 0xFF);
-            GRRLIB_Camera3dSettings(0.0, 0.0, 13.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0);
+            GRRLIB_Camera3dSettings(
+                0.0, 0.0, 13.0, 
+                0.0, 1.0, 0.0, 
+                0.0, 0.0, 0.0
+            );
         }
         self.model_factory.load_models();
     }
@@ -143,17 +149,20 @@ impl Renderer {
      */
     pub fn render_world(&mut self, world: &World) {
         let model = self.model_factory.get_model("Suzanne").unwrap();
-        for (_id, (position, _velocity)) in &mut world.query::<(&Position, &Velocity)>() {
+        for (_id, (position, _velocity)) in  &mut world.query::<(&Position, &Velocity)>()
+        {
             unsafe {
                 GRRLIB_3dMode(0.1, 1000.0, 45.0, false, false);
                 GRRLIB_ObjectView(
-                    position.x, position.y, position.z, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                    position.x, position.y, position.z, 
+                    0.0, 0.0, 0.0,
+                    1.0, 1.0, 1.0
                 );
-                Self::render_mesh(model);
+                Self::render_mesh(& model);
             }
         }
         unsafe {
             GRRLIB_Render();
         }
-    }
+    }   
 }

--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -1,6 +1,4 @@
-// Skip Clippy warnings for this module and nested modules:
-#[allow(clippy:all)]
-
+#[allow(clippy::all)]
 include!("renderer/grrlib.rs");
 
 mod inline;

--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -1,21 +1,22 @@
+#![allow(clippy::all)]
 include!("renderer/grrlib.rs");
 
 mod inline;
 pub use inline::*;
 
 mod model_factory;
-pub use model_factory::{ModelFactory};
+pub use model_factory::ModelFactory;
 
+use crate::{Position, Velocity};
 use hecs::*;
 use ogc_rs::print;
 use wavefront::Obj;
-use crate::{Position, Velocity};
 
 /**
  * Data structure for the renderer.
  */
 pub struct Renderer {
-    model_factory : ModelFactory<'static>
+    model_factory: ModelFactory<'static>,
 }
 
 /**
@@ -27,14 +28,14 @@ impl Renderer {
      */
     pub fn new() -> Renderer {
         Renderer {
-            model_factory: ModelFactory::new()
+            model_factory: ModelFactory::new(),
         }
     }
 
     /**
      * Allows for rendering the given object.
      */
-    fn render_mesh(object : & Obj) {
+    fn render_mesh(object: &Obj) {
         let col: [u32; 3] = [0xFFFFFFFF, 0xAAAAAAFF, 0x666666FF];
         unsafe {
             let vertex_count = (object.triangles().count() * 3) as u16;
@@ -57,59 +58,59 @@ impl Renderer {
         let col: [u32; 3] = [0xFFFFFFFF, 0xAAAAAAFF, 0x666666FF];
         unsafe {
             GX_Begin(GX_QUADS as u8, GX_VTXFMT0 as u8, 24u16);
-                GX_Position3f32(-1.0, 1.0, -1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(-1.0,-1.0,-1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(1.0,-1.0,-1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(1.0,1.0,-1.0);
-                GX_Color1u32(col[0]);
+            GX_Position3f32(-1.0, 1.0, -1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(-1.0, -1.0, -1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(1.0, -1.0, -1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(1.0, 1.0, -1.0);
+            GX_Color1u32(col[0]);
 
-                GX_Position3f32(-1.0,1.0,1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(-1.0,-1.0,1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(1.0,-1.0,1.0);
-                GX_Color1u32(col[0]);
-                GX_Position3f32(1.0,1.0,1.0);
-                GX_Color1u32(col[0]);
+            GX_Position3f32(-1.0, 1.0, 1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(-1.0, -1.0, 1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(1.0, -1.0, 1.0);
+            GX_Color1u32(col[0]);
+            GX_Position3f32(1.0, 1.0, 1.0);
+            GX_Color1u32(col[0]);
 
-                GX_Position3f32(-1.0,1.0,1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(1.0,1.0,1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(1.0,1.0,-1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(-1.0,1.0,-1.0);
-                GX_Color1u32(col[1]);
+            GX_Position3f32(-1.0, 1.0, 1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(1.0, 1.0, 1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(1.0, 1.0, -1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(-1.0, 1.0, -1.0);
+            GX_Color1u32(col[1]);
 
-                GX_Position3f32(-1.0,-1.0,1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(1.0,-1.0,1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(1.0,-1.0,-1.0);
-                GX_Color1u32(col[1]);
-                GX_Position3f32(-1.0,-1.0,-1.0);
-                GX_Color1u32(col[1]);
+            GX_Position3f32(-1.0, -1.0, 1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(1.0, -1.0, 1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(1.0, -1.0, -1.0);
+            GX_Color1u32(col[1]);
+            GX_Position3f32(-1.0, -1.0, -1.0);
+            GX_Color1u32(col[1]);
 
-                GX_Position3f32(-1.0,1.0,1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(-1.0,1.0,-1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(-1.0,-1.0,-1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(-1.0,-1.0,1.0);
-                GX_Color1u32(col[2]);
+            GX_Position3f32(-1.0, 1.0, 1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(-1.0, 1.0, -1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(-1.0, -1.0, -1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(-1.0, -1.0, 1.0);
+            GX_Color1u32(col[2]);
 
-                GX_Position3f32(1.0,1.0,1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(1.0,1.0,-1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(1.0,-1.0,-1.0);
-                GX_Color1u32(col[2]);
-                GX_Position3f32(1.0,-1.0,1.0);
-                GX_Color1u32(col[2]);
+            GX_Position3f32(1.0, 1.0, 1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(1.0, 1.0, -1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(1.0, -1.0, -1.0);
+            GX_Color1u32(col[2]);
+            GX_Position3f32(1.0, -1.0, 1.0);
+            GX_Color1u32(col[2]);
             GX_End();
         }
     }
@@ -123,11 +124,7 @@ impl Renderer {
             GRRLIB_Settings.antialias = true;
 
             GRRLIB_SetBackgroundColour(0x00, 0x00, 0x00, 0xFF);
-            GRRLIB_Camera3dSettings(
-                0.0, 0.0, 13.0, 
-                0.0, 1.0, 0.0, 
-                0.0, 0.0, 0.0
-            );
+            GRRLIB_Camera3dSettings(0.0, 0.0, 13.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0);
         }
         self.model_factory.load_models();
     }
@@ -146,20 +143,17 @@ impl Renderer {
      */
     pub fn render_world(&mut self, world: &World) {
         let model = self.model_factory.get_model("Suzanne").unwrap();
-        for (_id, (position, _velocity)) in  &mut world.query::<(&Position, &Velocity)>()
-        {
+        for (_id, (position, _velocity)) in &mut world.query::<(&Position, &Velocity)>() {
             unsafe {
                 GRRLIB_3dMode(0.1, 1000.0, 45.0, false, false);
                 GRRLIB_ObjectView(
-                    position.x, position.y, position.z, 
-                    0.0, 0.0, 0.0,
-                    1.0, 1.0, 1.0
+                    position.x, position.y, position.z, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
                 );
-                Self::render_mesh(& model);
+                Self::render_mesh(model);
             }
         }
         unsafe {
             GRRLIB_Render();
         }
-    }   
+    }
 }

--- a/docker/builder/build_watch.sh
+++ b/docker/builder/build_watch.sh
@@ -8,13 +8,18 @@ cd /app
 
 # Build function
 build () {
+    echo -e "\e[1;34m Running Rust formatter... \e[0m"
+    cargo +nightly fmt
+    echo -e "\e[1;34m Showing Clippy warnings... \e[0m"
+    cargo +nightly clippy --fix --allow-no-vcs --target=powerpc-unknown-eabi.json --color=always
+
     echo -e "\e[1;34m Starting main build... \e[0m"
-    cargo +nightly build -Z build-std=core,alloc --target powerpc-unknown-eabi.json
+    cargo +nightly build -Z build-std=core,alloc --target=powerpc-unknown-eabi.json --color=always
     cp /build/target/powerpc-unknown-eabi/debug/rust-wii.elf /build/bin/boot.elf
     echo -e "\e[1;32m Binary main build completed. \e[0m"
 
     echo -e "\e[1;34m Starting target-test build... \e[0m"
-    cargo +nightly build --features run_target_tests -Z build-std=core,alloc --target powerpc-unknown-eabi.json
+    cargo +nightly build --features run_target_tests -Z build-std=core,alloc --target=powerpc-unknown-eabi.json --color=always
     cp /build/target/powerpc-unknown-eabi/debug/rust-wii.elf /build/bin/boot-test.elf
     echo -e "\e[1;32m Binary target-test build completed. \e[0m"
 }

--- a/docker/builder/build_watch.sh
+++ b/docker/builder/build_watch.sh
@@ -11,7 +11,7 @@ build () {
     echo -e "\e[1;34m Running Rust formatter... \e[0m"
     cargo +nightly fmt
     echo -e "\e[1;34m Showing Clippy warnings... \e[0m"
-    cargo +nightly clippy --fix --allow-no-vcs --target=powerpc-unknown-eabi.json --color=always
+    cargo +nightly clippy --target=powerpc-unknown-eabi.json --color=always
 
     echo -e "\e[1;34m Starting main build... \e[0m"
     cargo +nightly build -Z build-std=core,alloc --target=powerpc-unknown-eabi.json --color=always

--- a/docker/builder/install_rust.sh
+++ b/docker/builder/install_rust.sh
@@ -3,3 +3,5 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup default nightly
 rustup component add rust-src --toolchain nightly
+rustup component add clippy --toolchain nightly
+rustup component add rustfmt --toolchain nightly


### PR DESCRIPTION
This ensures that on save, source files are automatically reformatted according to rustfmt rules.

Clippy warnings are shown before building. (But the build happens regardless). Besides this devs might add their own in-editor clippy config.

Clippy currently ignores the `renderer` module and its submodules, because the `grrrlib` source is included inline in that file.

It might be cleaner to separate this further (like the idea @LucvandenBrand mentioned earlier to put `grrrlib` in its own subcrate), so we truly only ignore the generated unsafe code, while still checking the main rendering logic. (Clippy complains about missing safety comments for each of the unsafe
functions :shrug: )


Fixes #27 