### PR TITLE
Improve RawDataStore

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7,7 +7,6 @@
 #![no_std]
 #![feature(start)]
 #![feature(slice_flatten)]
-#![feature(const_for)]
 
 // Make sure the allocator is set.
 extern crate alloc;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![feature(start)]
 #![feature(slice_flatten)]
+#![feature(const_for)]
 
 // Make sure the allocator is set.
 extern crate alloc;

--- a/app/src/raw_data_store.rs
+++ b/app/src/raw_data_store.rs
@@ -1,51 +1,26 @@
-use alloc::collections::BTreeMap;
-use alloc::vec::Vec;
-
 /**
- * All models must be defined in this list, which is filled at compile time.
+ * Enumerates all models that exist in the project.
+ * Each of them can be turned into its actual raw data by calling `to_data()` on it.
  */
-const RAW_DATA_LIST: [(&str, &'static [u8]); 4] = [
-    ("Suzanne", include_bytes!("../data/Suz.obj")),
-    ("Suzanne_mat", include_bytes!("../data/Suz.mtl")),
-    ("Triangle", include_bytes!("../data/Tri.obj")),
-    ("Triangle_mat", include_bytes!("../data/Tri.mtl")),
-];
-
-/**
- * Data structure for the raw data store
- */
-pub struct RawDataStore {
-    raw_data_map: BTreeMap<&'static str, &'static [u8]>,
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum ModelName {
+    Suzanne,
+    SuzanneMaterial,
+    Triangle,
+    TriangleMaterial,
 }
 
-/**
- * Implementation of the raw data store: allows for fast searching.
- */
-impl RawDataStore {
-    /**
-     * Create a new factory.
-     */
-    pub fn new() -> RawDataStore {
-        let mut store = RawDataStore {
-            raw_data_map: BTreeMap::new(),
-        };
-        store.load_references();
-        return store;
-    }
-
-    /**
-     * Load all references
-     */
-    fn load_references(&mut self) {
-        for entry in RAW_DATA_LIST {
-            self.raw_data_map.insert(entry.0, entry.1);
+impl ModelName {
+    /// Returns the raw model data of this particular ModelName
+    ///
+    /// Internally, `include_bytes!` is used
+    /// so each of the files in the ../data directory is included at compile time.
+    pub fn to_data(&self) -> &'static [u8] {
+        match self {
+            ModelName::Suzanne => include_bytes!("../data/Suz.obj"),
+            ModelName::SuzanneMaterial => include_bytes!("../data/Suz.mtl"),
+            ModelName::Triangle => include_bytes!("../data/Tri.obj"),
+            ModelName::TriangleMaterial => include_bytes!("../data/Tri.mtl"),
         }
-    }
-
-    /**
-     * Return the given raw data.
-     */
-    pub fn get(&mut self, key: &'static str) -> Option<&&'static [u8]> {
-        return self.raw_data_map.get(key);
     }
 }

--- a/app/src/raw_data_store.rs
+++ b/app/src/raw_data_store.rs
@@ -15,7 +15,7 @@ impl ModelName {
     ///
     /// Internally, `include_bytes!` is used
     /// so each of the files in the ../data directory is included at compile time.
-    pub fn to_data(&self) -> &'static [u8] {
+    pub const fn to_data(&self) -> &'static [u8] {
         match self {
             ModelName::Suzanne => include_bytes!("../data/Suz.obj"),
             ModelName::SuzanneMaterial => include_bytes!("../data/Suz.mtl"),

--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -7,6 +7,7 @@ pub use inline::*;
 
 mod indexed_model;
 mod model_factory;
+use crate::raw_data_store::ModelName;
 use indexed_model::IndexedModel;
 use model_factory::ModelFactory;
 
@@ -65,7 +66,7 @@ impl Renderer {
      * Render the scene
      */
     pub fn render_world(&mut self, world: &World) {
-        let mut model = self.model_factory.get_model("Suzanne").unwrap();
+        let mut model = self.model_factory.get_model(ModelName::Suzanne).unwrap();
         for (_id, (position, _velocity)) in &mut world.query::<(&Position, &Velocity)>() {
             unsafe {
                 GRRLIB_3dMode(0.1, 1000.0, 45.0, false, false);

--- a/app/src/renderer/model_factory.rs
+++ b/app/src/renderer/model_factory.rs
@@ -4,20 +4,20 @@ use alloc::vec::Vec;
 use ogc_rs::print;
 use wavefront::Obj;
 
-use crate::raw_data_store::RawDataStore;
+use crate::raw_data_store::ModelName;
 
 use super::indexed_model::IndexedModel;
 
 /**
  * All models must be defined in this list, which is filled at compile time.
  */
-const MODEL_KEYS: [&str; 1] = ["Suzanne"];
+const MODEL_KEYS: [ModelName; 1] = [ModelName::Suzanne];
 
 /**
  * Data structure for the model factory.
  */
 pub struct ModelFactory {
-    models: BTreeMap<&'static str, IndexedModel>,
+    models: BTreeMap<ModelName, IndexedModel>,
 }
 
 /**
@@ -37,13 +37,12 @@ impl ModelFactory {
      * Load all models.
      */
     pub fn load_models(&mut self) {
-        let mut store = RawDataStore::new();
-        for key in MODEL_KEYS {
-            let raw_data = store.get(key).unwrap();
+        for model in MODEL_KEYS {
+            let raw_data = model.to_data();
             let string_data = from_utf8(raw_data).unwrap();
             match Obj::from_lines(string_data.lines()) {
                 Ok(object) => {
-                    self.models.insert(key, IndexedModel::new(&object));
+                    self.models.insert(model, IndexedModel::new(&object));
                 }
                 Err(error) => {
                     print!("Error loading model: {}", error);
@@ -55,7 +54,7 @@ impl ModelFactory {
     /**
      * Return the given model.
      */
-    pub fn get_model(&mut self, key: &'static str) -> Option<&mut IndexedModel> {
-        return self.models.get_mut(key);
+    pub fn get_model(&mut self, key: ModelName) -> Option<&mut IndexedModel> {
+        return self.models.get_mut(&key);
     }
 }

--- a/app/src/renderer/model_factory.rs
+++ b/app/src/renderer/model_factory.rs
@@ -28,9 +28,11 @@ impl ModelFactory {
      * Create a new factory.
      */
     pub fn new() -> ModelFactory {
-        ModelFactory {
+        let mut res = ModelFactory {
             models: BTreeMap::new(),
-        }
+        };
+        res.load_models();
+        res
     }
 
     /**
@@ -45,7 +47,7 @@ impl ModelFactory {
                     self.models.insert(model, IndexedModel::new(&object));
                 }
                 Err(error) => {
-                    print!("Error loading model: {}", error);
+                    println!("Error loading model: {}", error);
                 }
             }
         }

--- a/app/src/renderer/model_factory.rs
+++ b/app/src/renderer/model_factory.rs
@@ -28,11 +28,9 @@ impl ModelFactory {
      * Create a new factory.
      */
     pub fn new() -> ModelFactory {
-        let mut res = ModelFactory {
+        ModelFactory {
             models: BTreeMap::new(),
-        };
-        res.load_models();
-        res
+        }
     }
 
     /**
@@ -47,7 +45,7 @@ impl ModelFactory {
                     self.models.insert(model, IndexedModel::new(&object));
                 }
                 Err(error) => {
-                    println!("Error loading model: {}", error);
+                    print!("Error loading model: {}", error);
                 }
             }
         }


### PR DESCRIPTION
Fixes #43 

The final version does not end up using `enum-map` as it does not really add any useful functionality if your map is is a static constant.

The cleanest solution turned out to be a lookup table implemented as a simple function.

---

Questions: 
- Maybe we want a separate list for materials?
- The file has become simple enough that it might be worthwhile to just include this logic in the ModelFactory file.
- If we have a separate models and materials list, we might combine the models list with the MODEL_KEYS in ModelFactory for even more refactoring. What do you think?