### PR TITLE
Allows Renderer::render_mesh to take a const ref and apply resulting refactors:

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![feature(start)]
 #![feature(slice_flatten)]
+#![feature(slice_ptr_get)]
 
 // Make sure the allocator is set.
 extern crate alloc;
@@ -54,8 +55,7 @@ fn main_game() -> isize {
     let mut all_query = PreparedQuery::<(&mut Position, &mut Velocity)>::default();
 
     // Kickstart main loop.
-    let mut renderer = Renderer::new();
-    renderer.init_render();
+    let renderer = Renderer::new();
     loop {
         Input::update(ControllerType::Wii);
         if wii_mote.is_button_down(Button::Home) {
@@ -69,6 +69,5 @@ fn main_game() -> isize {
 
         renderer.render_world(&world);
     }
-    renderer.close_render();
     0
 }

--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -18,30 +18,36 @@ use wavefront::{Obj, Vertex};
 use libc::c_void;
 use ogc_rs::prelude::Vec;
 
-/**
- * Data structure for the renderer.
- */
+/// Representation of the graphics rendering subsystem of the device
+///
+/// As the device only has _one_ graphics chip which is exposed as a globally mutable state machine,
+/// at most one Renderer should be constructed at any time.
+///
+/// Graphics setup happens as part of initialization,
+/// and cleanup happens automatically on drop.
 pub struct Renderer {
     model_factory: ModelFactory,
 }
 
-/**
- * Renderer implementation: provides the main interface for rendering stuff in the game.
- */
 impl Renderer {
-    /**
-     * Create a new renderer.
-     */
+    ///
+    /// Create a new renderer.
+    ///
+    /// As part of this:
+    /// - the graphics chip is initialized in the expected rendering mode.
+    /// - The available models are constructed and indexed. (c.f. `ModelFactory`)
     pub fn new() -> Renderer {
-        Renderer {
+        let res = Renderer {
             model_factory: ModelFactory::new(),
-        }
+        };
+        res.init_render();
+        res
     }
 
     /**
      * Initialize the renderer, which means GRRLIB and loading all models.
      */
-    pub fn init_render(&mut self) {
+    fn init_render(&self) {
         unsafe {
             GRRLIB_Init();
             GRRLIB_Settings.antialias = true;
@@ -49,47 +55,53 @@ impl Renderer {
             GRRLIB_SetBackgroundColour(0x00, 0x00, 0x00, 0xFF);
             GRRLIB_Camera3dSettings(0.0, 0.0, 13.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0);
         }
-        self.model_factory.load_models();
     }
 
     /**
-     * Cleanup the renderer
+     * Render the entire scene.
+     * As part of this, refreshes the graphics buffer and wait for the next frame.
      */
-    pub fn close_render(&mut self) {
+    pub fn render_world(&self, world: &World) {
+        let model = self.model_factory.get_model("Suzanne").unwrap();
+        for (entity, (position, _velocity)) in &mut world.query::<(&Position, &Velocity)>() {
+            self.render_entity(model, entity, position);
+        }
+        self.redraw_world();
+    }
+
+    /// Render a single entity
+    fn render_entity(&self, model: &IndexedModel, _entity: Entity, position: &Position) {
         unsafe {
-            GRRLIB_Exit();
+            GRRLIB_3dMode(0.1, 1000.0, 45.0, false, false);
+            GRRLIB_ObjectView(
+                position.x, position.y, position.z, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+            );
+            Self::render_mesh(model);
         }
     }
 
-    /**
-     * Render the scene
-     */
-    pub fn render_world(&mut self, world: &World) {
-        let mut model = self.model_factory.get_model("Suzanne").unwrap();
-        for (_id, (position, _velocity)) in &mut world.query::<(&Position, &Velocity)>() {
-            unsafe {
-                GRRLIB_3dMode(0.1, 1000.0, 45.0, false, false);
-                GRRLIB_ObjectView(
-                    position.x, position.y, position.z, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
-                );
-                Self::render_mesh(&mut model);
-            }
-        }
+    /// Refreshes the visible graphics;
+    /// Usually called as part of `render_world`
+    /// but separately exposed for easier testing.
+    pub fn redraw_world(&self) {
         unsafe {
             GRRLIB_Render();
         }
     }
 
     /**
-     * Allows for rendering the given object.
+     * Renders the given model at whatever position was set previously using other calls into GRRLIB / GX.
+     *
+     * ## Safety
+     * We call GX_SetArray which takes a pointer into the vertices of the model as '*void *' (C syntax) AKA '*mut c_void' (Rust syntax).
+     * By cheking the implementation of GX_SetArray it is clear that this signature is wrong; the argument is only used for reading and not mutated.
+     * In other words: The argument is treated as if it were a 'const *void' (C syntax) AKA '*const c_void' (Rust syntax).
+     * As such, it is OK to turn the immutable reference into a mutable pointer.
      */
-    fn render_mesh(model: &mut IndexedModel) {
+    fn render_mesh(model: &IndexedModel) {
+        let vertices_ptr = model.vertices.as_ptr().cast_mut() as *mut c_void;
         unsafe {
-            GX_SetArray(
-                GX_VA_POS,
-                model.vertices.as_mut_ptr() as *mut c_void,
-                (4 * 3) as u8,
-            );
+            GX_SetArray(GX_VA_POS, vertices_ptr, (4 * 3) as u8);
             GX_SetVtxDesc(GX_VA_POS as u8, GX_INDEX16 as u8);
             GX_SetVtxDesc(GX_VA_CLR0 as u8, GX_DIRECT as u8);
             GX_SetVtxAttrFmt(GX_VTXFMT0 as u8, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
@@ -106,6 +118,15 @@ impl Renderer {
                 GX_Color3f32(1.0, 1.0, 1.0);
             }
             GX_End();
+        }
+    }
+}
+
+impl Drop for Renderer {
+    /// Cleanup the renderer
+    fn drop(&mut self) {
+        unsafe {
+            GRRLIB_Exit();
         }
     }
 }

--- a/app/src/renderer/indexed_model.rs
+++ b/app/src/renderer/indexed_model.rs
@@ -5,6 +5,7 @@ use wavefront::{Obj, Vertex};
 /**
  * Our representation of a model.
  */
+#[derive(Debug)]
 pub struct IndexedModel {
     pub vertices: Vec<f32>,
     pub indices: Vec<u16>,

--- a/app/src/renderer/model_factory.rs
+++ b/app/src/renderer/model_factory.rs
@@ -16,6 +16,7 @@ const MODEL_KEYS: [&str; 1] = ["Suzanne"];
 /**
  * Data structure for the model factory.
  */
+#[derive(Debug)]
 pub struct ModelFactory {
     models: BTreeMap<&'static str, IndexedModel>,
 }
@@ -28,9 +29,11 @@ impl ModelFactory {
      * Create a new factory.
      */
     pub fn new() -> ModelFactory {
-        ModelFactory {
-            models: BTreeMap::new(),
-        }
+        let mut res: Self = ModelFactory {
+            models: Default::default(),
+        };
+        res.load_models();
+        res
     }
 
     /**
@@ -55,7 +58,7 @@ impl ModelFactory {
     /**
      * Return the given model.
      */
-    pub fn get_model(&mut self, key: &'static str) -> Option<&mut IndexedModel> {
-        return self.models.get_mut(key);
+    pub fn get_model(&self, key: &'static str) -> Option<&IndexedModel> {
+        return self.models.get(key);
     }
 }


### PR DESCRIPTION
Allows Renderer::render_mesh to take a const ref and apply resulting refactors:
- Allow taking things immutably where now possible
- Make Renderer follow RAII
- Documentation for refactored functions

Fixes #45 