### PR TITLE
Improvements to shutdown logic

### DIFF
--- a/app/src/renderer.rs
+++ b/app/src/renderer.rs
@@ -126,6 +126,7 @@ impl Renderer {
 impl Drop for Renderer {
     /// Cleanup the renderer
     fn drop(&mut self) {
+        println!("Dropping Renderer");
         unsafe {
             GRRLIB_Exit();
         }


### PR DESCRIPTION
@Gezzellig these are some changes to handle the shutdown logic.
This PR merges into your original PR. Feel free to review it and do with the changes whatever you want.

Differences:

- Use `AtomicBool` for the global flag. This means the flag does not need to be `static mut` for which all access is unsafe, so a lot of the unsafe code can now be turned into safe code 😊 .
- Turns out Rust happily casts a function pointer in an option to a nullable C-style function pointer, simplifying the callback registration code.
- Moved some of the logic into dedicated small functions so any calls into (unsafe) C libraries are wrapped inside documented Rust functions.