### PR TITLE
Fixes Clippy warning about 'assert being optimized away'

### DIFF
--- a/app/src/target_tests/mod.rs
+++ b/app/src/target_tests/mod.rs
@@ -4,7 +4,11 @@ use ogc_rs::*;
 pub fn tests() -> HashMap<&'static str, fn()> {
     let mut tests: HashMap<&'static str, fn()> = HashMap::new();
 
-    tests.insert("Trivial test", || assert!(true));
+    tests.insert("Trivial test", || {
+        let myvar = 1;
+        let expected = 1;
+        assert_eq!(myvar, expected);
+    });
 
     // tests.insert("Problematic test", || {
     //     assert!(1 == 0)


### PR DESCRIPTION
This PR fixes Clippy warning about 'assert being optimized away' in the integration test suite